### PR TITLE
[#10] Polish UI design across all prototype views

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,13 +1,17 @@
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import Sidebar from "./Sidebar";
 import ChatPopover from "./chat/ChatPopover";
 
 export default function Layout() {
+  const location = useLocation();
+
   return (
     <div className="flex h-screen overflow-hidden">
       <Sidebar />
-      <main className="flex-1 overflow-auto">
-        <Outlet />
+      <main className="flex-1 overflow-auto" key={location.pathname}>
+        <div className="animate-page-enter">
+          <Outlet />
+        </div>
       </main>
       <ChatPopover />
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from "react-router-dom";
-import { House, GitBranch, Settings, MessageCircle, ChevronsUpDown, Check, Bot } from "lucide-react";
+import { House, GitBranch, Settings, MessageCircle, ChevronsUpDown, Check, Bot, Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -25,7 +25,7 @@ const navItems = [
 ] as const;
 
 export default function Sidebar() {
-  const { currentProject, setCurrentProject, openChatDefault } = useApp();
+  const { currentProject, setCurrentProject, openChatDefault, isDark, toggleTheme } = useApp();
 
   return (
     <aside className="flex h-screen w-60 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground">
@@ -35,10 +35,15 @@ export default function Sidebar() {
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
-              className="w-full justify-between font-medium"
+              className="w-full justify-between font-medium shadow-sm transition-all duration-150 hover:shadow-md"
               size="lg"
             >
-              <span className="truncate">{currentProject.name}</span>
+              <div className="flex items-center gap-2 truncate">
+                <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-primary/10 text-[10px] font-bold text-primary">
+                  {currentProject.name.charAt(0).toUpperCase()}
+                </span>
+                <span className="truncate">{currentProject.name}</span>
+              </div>
               <ChevronsUpDown className="ml-1 size-4 shrink-0 opacity-50" />
             </Button>
           </DropdownMenuTrigger>
@@ -47,11 +52,16 @@ export default function Sidebar() {
               <DropdownMenuItem
                 key={project.id}
                 onSelect={() => setCurrentProject(project)}
-                className="flex items-center justify-between"
+                className="flex items-center justify-between transition-colors"
               >
-                <span className="truncate">{project.name}</span>
+                <span className="flex items-center gap-2 truncate">
+                  <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-primary/10 text-[10px] font-bold text-primary">
+                    {project.name.charAt(0).toUpperCase()}
+                  </span>
+                  <span className="truncate">{project.name}</span>
+                </span>
                 {project.id === currentProject.id && (
-                  <Check className="ml-2 size-4 shrink-0" />
+                  <Check className="ml-2 size-4 shrink-0 text-primary" />
                 )}
               </DropdownMenuItem>
             ))}
@@ -62,8 +72,8 @@ export default function Sidebar() {
       <Separator />
 
       {/* Navigation links */}
-      <nav className="flex-1 p-3">
-        <ul className="flex flex-col gap-1">
+      <nav className="flex-1 px-2 py-3">
+        <ul className="flex flex-col gap-0.5">
           {navItems.map(({ to, label, icon: Icon }) => (
             <li key={to}>
               <NavLink
@@ -71,10 +81,10 @@ export default function Sidebar() {
                 end={to === "/"}
                 className={({ isActive }) =>
                   cn(
-                    "flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                    "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-all duration-150",
                     isActive
-                      ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                      : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground"
+                      ? "nav-active-bar bg-sidebar-accent text-sidebar-accent-foreground shadow-sm"
+                      : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground hover:translate-x-0.5"
                   )
                 }
               >
@@ -88,14 +98,39 @@ export default function Sidebar() {
 
       <Separator />
 
-      {/* Chat with OP button */}
-      <div className="p-3">
+      {/* Bottom actions */}
+      <div className="flex flex-col gap-2 p-3">
+        {/* Dark mode toggle */}
+        <div className="flex items-center justify-between px-1">
+          <span className="text-xs text-muted-foreground">Theme</span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7 transition-transform duration-200 hover:rotate-12"
+                onClick={toggleTheme}
+              >
+                {isDark ? (
+                  <Sun className="size-4 text-amber-400" />
+                ) : (
+                  <Moon className="size-4" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              <p>Switch to {isDark ? "light" : "dark"} mode</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+
+        {/* Chat with OP button */}
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
               variant="outline"
               size="lg"
-              className="w-full gap-2"
+              className="w-full gap-2 shadow-sm transition-all duration-150 hover:shadow-md"
               onClick={() => openChatDefault()}
             >
               <MessageCircle className="size-4" />

--- a/src/components/agents/AgentActivityPanel.tsx
+++ b/src/components/agents/AgentActivityPanel.tsx
@@ -42,42 +42,48 @@ export default function AgentActivityPanel() {
     <div className="border-t border-border bg-card">
       {/* Header bar */}
       <button
-        className="flex w-full items-center justify-between px-4 py-2 text-sm font-medium hover:bg-accent/50 transition-colors"
+        className="flex w-full items-center justify-between px-4 py-2.5 text-sm font-medium hover:bg-accent/50 transition-colors"
         onClick={() => setExpanded(!expanded)}
       >
         <div className="flex items-center gap-3">
           <Bot className="size-4 text-muted-foreground" />
           <span>Agent Activity</span>
-          <Badge variant="secondary" className="text-xs font-mono">
+          <Badge
+            variant="secondary"
+            className="font-technical text-xs"
+          >
             {summary.running}/{summary.totalSlots} active
-            {summary.queued > 0 && `, ${summary.queued} queued`}
+            {summary.queued > 0 && ` | ${summary.queued} queued`}
           </Badge>
         </div>
         {expanded ? (
-          <ChevronDown className="size-4 text-muted-foreground" />
+          <ChevronDown className="size-4 text-muted-foreground transition-transform" />
         ) : (
-          <ChevronUp className="size-4 text-muted-foreground" />
+          <ChevronUp className="size-4 text-muted-foreground transition-transform" />
         )}
       </button>
 
       {/* Expandable content */}
       {expanded && (
-        <div className="flex gap-3 overflow-x-auto px-4 pb-3">
+        <div className="animate-panel-expand flex gap-3 overflow-x-auto px-4 pb-3">
           {activeSessions.map((session) => {
             const issue = mockIssues.find((i) => i.id === session.issueId);
+            const isRunning = session.status === "running";
             return (
               <div
                 key={session.id}
-                className="flex min-w-[220px] flex-col gap-1.5 rounded-lg border border-border bg-background p-3"
+                className="hover-lift flex min-w-[220px] flex-col gap-1.5 rounded-lg border border-border bg-background p-3 transition-all duration-150"
                 style={{ borderLeftColor: session.color, borderLeftWidth: 3 }}
               >
                 <div className="flex items-center justify-between">
-                  <span className="text-xs font-mono text-muted-foreground">
+                  <span className="font-technical text-xs text-muted-foreground">
                     {issue ? `#${issue.issueNumber}` : session.sessionId.slice(0, 16)}
                   </span>
-                  <span className="flex items-center gap-1">
+                  <span className="flex items-center gap-1.5">
                     <span
-                      className={`inline-block size-2 rounded-full ${statusColors[session.status]}`}
+                      className={`inline-block size-2 rounded-full ${statusColors[session.status]} ${
+                        isRunning ? "animate-status-pulse" : ""
+                      }`}
                     />
                     <span className="text-xs capitalize text-muted-foreground">
                       {session.status}
@@ -90,11 +96,11 @@ export default function AgentActivityPanel() {
                 <div className="flex items-center gap-3 text-xs text-muted-foreground">
                   <span className="flex items-center gap-1">
                     <Cpu className="size-3" />
-                    {session.currentStep}
+                    <span className="font-technical">{session.currentStep}</span>
                   </span>
                   <span className="flex items-center gap-1">
                     <Clock className="size-3" />
-                    {formatElapsed(session.startedAt)}
+                    <span className="font-technical">{formatElapsed(session.startedAt)}</span>
                   </span>
                 </div>
               </div>
@@ -111,7 +117,7 @@ export default function AgentActivityPanel() {
             <Button
               variant="ghost"
               size="sm"
-              className="text-xs text-muted-foreground"
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors"
               asChild
             >
               <a href="/agents">View all &rarr;</a>

--- a/src/components/agents/EventFeed.tsx
+++ b/src/components/agents/EventFeed.tsx
@@ -12,13 +12,18 @@ interface EventFeedProps {
 }
 
 const eventTypeColors: Record<string, string> = {
-  session_start: "bg-green-100 text-green-800",
-  session_end: "bg-gray-100 text-gray-800",
-  PreToolUse: "bg-blue-100 text-blue-800",
-  PostToolUse: "bg-indigo-100 text-indigo-800",
-  SubagentStart: "bg-purple-100 text-purple-800",
-  SubagentStop: "bg-purple-100 text-purple-800",
-  hitl_blocked: "bg-yellow-100 text-yellow-800",
+  session_start: "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300",
+  session_end: "bg-gray-100 text-gray-800 dark:bg-gray-800/40 dark:text-gray-300",
+  PreToolUse: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300",
+  PostToolUse: "bg-indigo-100 text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-300",
+  SubagentStart: "bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300",
+  SubagentStop: "bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300",
+  hitl_blocked: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300",
+};
+
+const sourceBadgeStyles: Record<string, string> = {
+  orchestration: "bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300",
+  hook: "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300",
 };
 
 function formatTimestamp(ts: string): string {
@@ -81,14 +86,14 @@ export default function EventFeed({ events, projectId }: EventFeedProps) {
   };
 
   return (
-    <div className="rounded-lg border border-border bg-card">
-      <div className="flex items-center justify-between border-b border-border px-4 py-2">
+    <div className="rounded-xl border border-border bg-card shadow-sm">
+      <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
         <h3 className="text-sm font-semibold">Live Event Feed</h3>
         <div className="flex items-center gap-2">
           <Filter className="size-3.5 text-muted-foreground" />
           {/* Event type filter */}
           <select
-            className="rounded border border-border bg-background px-2 py-0.5 text-xs"
+            className="rounded-md border border-border bg-background px-2 py-1 font-technical text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring"
             value={filterType ?? ""}
             onChange={(e) =>
               setFilterType(e.target.value || null)
@@ -103,7 +108,7 @@ export default function EventFeed({ events, projectId }: EventFeedProps) {
           </select>
           {/* Session filter */}
           <select
-            className="rounded border border-border bg-background px-2 py-0.5 text-xs"
+            className="rounded-md border border-border bg-background px-2 py-1 font-technical text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring"
             value={filterSession ?? ""}
             onChange={(e) =>
               setFilterSession(e.target.value || null)
@@ -130,11 +135,14 @@ export default function EventFeed({ events, projectId }: EventFeedProps) {
               (s) => s.id === event.agentSessionId
             );
             return (
-              <div key={event.id} className="px-4 py-2">
+              <div
+                key={event.id}
+                className="px-4 py-1.5 transition-colors hover:bg-accent/30"
+              >
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="w-full justify-start gap-2 px-0 h-auto py-1"
+                  className="w-full justify-start gap-2 px-0 h-auto py-1 hover:bg-transparent"
                   onClick={() => toggleExpand(event.id)}
                 >
                   {isExpanded ? (
@@ -142,7 +150,7 @@ export default function EventFeed({ events, projectId }: EventFeedProps) {
                   ) : (
                     <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
                   )}
-                  <span className="text-xs font-mono text-muted-foreground w-16 shrink-0 text-left">
+                  <span className="font-technical text-xs text-muted-foreground w-16 shrink-0 text-left">
                     {formatTimestamp(event.timestamp)}
                   </span>
                   {session && (
@@ -153,19 +161,27 @@ export default function EventFeed({ events, projectId }: EventFeedProps) {
                   )}
                   <Badge
                     variant="secondary"
-                    className={`text-[10px] ${eventTypeColors[event.eventType] ?? "bg-gray-100 text-gray-800"}`}
+                    className={`text-[10px] border-none ${eventTypeColors[event.eventType] ?? "bg-gray-100 text-gray-800 dark:bg-gray-800/40 dark:text-gray-300"}`}
                   >
                     {event.eventType}
                   </Badge>
                   {event.toolName && (
-                    <span className="text-xs font-medium">{event.toolName}</span>
+                    <Badge
+                      variant="outline"
+                      className="font-technical text-[10px] font-medium"
+                    >
+                      {event.toolName}
+                    </Badge>
                   )}
-                  <span className="text-xs text-muted-foreground truncate">
-                    {event.source === "orchestration" ? "[orch]" : "[hook]"}
-                  </span>
+                  <Badge
+                    variant="secondary"
+                    className={`text-[10px] border-none ${sourceBadgeStyles[event.source] ?? ""}`}
+                  >
+                    {event.source}
+                  </Badge>
                 </Button>
                 {isExpanded && (
-                  <pre className="ml-7 mt-1 rounded bg-muted p-2 text-xs font-mono overflow-x-auto whitespace-pre-wrap">
+                  <pre className="ml-7 mt-1 rounded-lg bg-muted/60 p-3 text-xs font-technical overflow-x-auto whitespace-pre-wrap border border-border/50">
                     {JSON.stringify(event.payload, null, 2)}
                   </pre>
                 )}

--- a/src/components/agents/PulseChart.tsx
+++ b/src/components/agents/PulseChart.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useState, useMemo } from "react";
 import type { AgentEvent, AgentSession } from "@/types";
+import { useApp } from "@/context/AppContext";
 
 interface PulseChartProps {
   events: AgentEvent[];
@@ -20,6 +21,7 @@ const WINDOWS: TimeWindow[] = ["1m", "3m", "5m", "10m"];
 export default function PulseChart({ events, sessions }: PulseChartProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [timeWindow, setTimeWindow] = useState<TimeWindow>("5m");
+  const { isDark } = useApp();
 
   // Use a fixed "now" based on the latest event for demo purposes
   const now = useMemo(() => {
@@ -79,6 +81,27 @@ export default function PulseChart({ events, sessions }: PulseChartProps) {
 
     ctx.clearRect(0, 0, w, h);
 
+    // Theme-aware colors
+    const colors = isDark
+      ? {
+          gridLine: "rgba(255, 255, 255, 0.06)",
+          axisLabel: "#64748b",
+          eventBar: "rgba(129, 140, 248, 0.35)",
+          toolBar: "#22d3ee",
+          toolBarAlpha: "rgba(34, 211, 238, 0.8)",
+          agentLine: "#fbbf24",
+          agentDot: "#fbbf24",
+        }
+      : {
+          gridLine: "#e5e7eb",
+          axisLabel: "#9ca3af",
+          eventBar: "rgba(99, 102, 241, 0.25)",
+          toolBar: "#06b6d4",
+          toolBarAlpha: "rgba(6, 182, 212, 0.8)",
+          agentLine: "#f59e0b",
+          agentDot: "#f59e0b",
+        };
+
     const padding = { top: 20, right: 16, bottom: 30, left: 40 };
     const chartW = w - padding.left - padding.right;
     const chartH = h - padding.top - padding.bottom;
@@ -92,50 +115,60 @@ export default function PulseChart({ events, sessions }: PulseChartProps) {
 
     const barWidth = chartW / bucketCount;
 
-    // Grid lines
-    ctx.strokeStyle = "#e5e7eb";
+    // Grid lines with labels
     ctx.lineWidth = 0.5;
     const gridLines = 4;
     for (let i = 0; i <= gridLines; i++) {
       const y = padding.top + chartH - (chartH * i) / gridLines;
+
+      ctx.strokeStyle = colors.gridLine;
       ctx.beginPath();
       ctx.moveTo(padding.left, y);
       ctx.lineTo(w - padding.right, y);
       ctx.stroke();
 
-      ctx.fillStyle = "#9ca3af";
-      ctx.font = "10px 'Geist Variable', monospace";
+      ctx.fillStyle = colors.axisLabel;
+      ctx.font = "10px 'Geist Mono', ui-monospace, monospace";
       ctx.textAlign = "right";
       const label = Math.round((maxVal * i) / gridLines);
       ctx.fillText(String(label), padding.left - 6, y + 3);
     }
 
-    // Event rate bars (background)
-    ctx.globalAlpha = 0.3;
+    // Event rate bars (background) with rounded top
     eventBuckets.forEach((val, i) => {
       const x = padding.left + i * barWidth;
       const barH = (val / maxVal) * chartH;
-      ctx.fillStyle = "#6366f1";
-      ctx.fillRect(x + 1, padding.top + chartH - barH, barWidth - 2, barH);
+      if (barH < 1) return;
+      ctx.fillStyle = colors.eventBar;
+      const radius = Math.min(3, barH / 2);
+      ctx.beginPath();
+      ctx.roundRect(x + 1, padding.top + chartH - barH, barWidth - 2, barH, [radius, radius, 0, 0]);
+      ctx.fill();
     });
-    ctx.globalAlpha = 1;
 
-    // Tool call bars (foreground)
+    // Tool call bars (foreground) with rounded top
     toolBuckets.forEach((val, i) => {
       const x = padding.left + i * barWidth;
       const barH = (val / maxVal) * chartH;
-      ctx.fillStyle = "#06b6d4";
-      ctx.fillRect(
+      if (barH < 1) return;
+      ctx.fillStyle = colors.toolBarAlpha;
+      const radius = Math.min(3, barH / 2);
+      ctx.beginPath();
+      ctx.roundRect(
         x + barWidth * 0.15,
         padding.top + chartH - barH,
         barWidth * 0.7,
-        barH
+        barH,
+        [radius, radius, 0, 0]
       );
+      ctx.fill();
     });
 
-    // Active agent line
-    ctx.strokeStyle = "#f59e0b";
+    // Active agent line with glow
+    ctx.strokeStyle = colors.agentLine;
     ctx.lineWidth = 2;
+    ctx.shadowColor = colors.agentLine;
+    ctx.shadowBlur = 6;
     ctx.beginPath();
     activeBuckets.forEach((val, i) => {
       const x = padding.left + i * barWidth + barWidth / 2;
@@ -144,6 +177,7 @@ export default function PulseChart({ events, sessions }: PulseChartProps) {
       else ctx.lineTo(x, y);
     });
     ctx.stroke();
+    ctx.shadowBlur = 0;
 
     // Active agent dots
     activeBuckets.forEach((val, i) => {
@@ -151,13 +185,16 @@ export default function PulseChart({ events, sessions }: PulseChartProps) {
       const y = padding.top + chartH - (val / maxVal) * chartH;
       ctx.beginPath();
       ctx.arc(x, y, 3, 0, Math.PI * 2);
-      ctx.fillStyle = "#f59e0b";
+      ctx.fillStyle = colors.agentDot;
       ctx.fill();
+      ctx.strokeStyle = isDark ? "#1e293b" : "#ffffff";
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
     });
 
     // X-axis time labels
-    ctx.fillStyle = "#9ca3af";
-    ctx.font = "10px 'Geist Variable', monospace";
+    ctx.fillStyle = colors.axisLabel;
+    ctx.font = "10px 'Geist Mono', ui-monospace, monospace";
     ctx.textAlign = "center";
     const startTime = now - windowMs;
     const labelInterval = Math.max(1, Math.floor(bucketCount / 5));
@@ -167,35 +204,35 @@ export default function PulseChart({ events, sessions }: PulseChartProps) {
       const x = padding.left + i * barWidth + barWidth / 2;
       ctx.fillText(label, x, h - padding.bottom + 16);
     }
-  }, [eventBuckets, toolBuckets, activeBuckets, bucketCount, now, windowMs, bucketMs]);
+  }, [eventBuckets, toolBuckets, activeBuckets, bucketCount, now, windowMs, bucketMs, isDark]);
 
   return (
-    <div className="rounded-lg border border-border bg-card">
-      <div className="flex items-center justify-between border-b border-border px-4 py-2">
+    <div className="rounded-xl border border-border bg-card shadow-sm">
+      <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
         <h3 className="text-sm font-semibold">Pulse Chart</h3>
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-3 text-xs text-muted-foreground">
-            <span className="flex items-center gap-1">
+            <span className="flex items-center gap-1.5">
               <span className="inline-block size-2.5 rounded-sm bg-indigo-500 opacity-30" />
               Events
             </span>
-            <span className="flex items-center gap-1">
+            <span className="flex items-center gap-1.5">
               <span className="inline-block size-2.5 rounded-sm bg-cyan-500" />
               Tools
             </span>
-            <span className="flex items-center gap-1">
+            <span className="flex items-center gap-1.5">
               <span className="inline-block size-2.5 rounded-full bg-amber-500" />
-              Active agents
+              Active
             </span>
           </div>
-          <div className="flex rounded-md border border-border overflow-hidden">
+          <div className="flex rounded-lg border border-border overflow-hidden">
             {WINDOWS.map((w) => (
               <button
                 key={w}
-                className={`px-2 py-0.5 text-xs font-medium transition-colors ${
+                className={`px-2.5 py-1 font-technical text-xs font-medium transition-colors ${
                   w === timeWindow
                     ? "bg-primary text-primary-foreground"
-                    : "hover:bg-accent"
+                    : "hover:bg-accent text-muted-foreground"
                 }`}
                 onClick={() => setTimeWindow(w)}
               >

--- a/src/components/agents/SwimLanes.tsx
+++ b/src/components/agents/SwimLanes.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useMemo } from "react";
 import type { AgentSession, AgentEvent } from "@/types";
 import { mockIssues } from "@/data/mock-data";
 import { mockProjects } from "@/data/mock-projects";
+import { useApp } from "@/context/AppContext";
 
 interface SwimLanesProps {
   sessions: AgentSession[];
@@ -30,6 +31,7 @@ function getToolColor(toolName: string | null): string {
 
 export default function SwimLanes({ sessions, events }: SwimLanesProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const { isDark } = useApp();
 
   const activeSessions = useMemo(
     () => sessions.filter((s) => s.status === "running" || s.status === "queued"),
@@ -71,6 +73,29 @@ export default function SwimLanes({ sessions, events }: SwimLanesProps) {
     canvas.style.height = `${height}px`;
     ctx.scale(dpr, dpr);
 
+    // Theme-aware colors
+    const colors = isDark
+      ? {
+          laneBg: "rgba(30, 41, 59, 0.4)",
+          queuedBg: "rgba(113, 63, 18, 0.2)",
+          border: "rgba(255, 255, 255, 0.08)",
+          textPrimary: "#e2e8f0",
+          textSecondary: "#94a3b8",
+          textTertiary: "#64748b",
+          axisLine: "rgba(255, 255, 255, 0.1)",
+          gridLine: "rgba(255, 255, 255, 0.06)",
+        }
+      : {
+          laneBg: "rgba(240, 249, 255, 0.5)",
+          queuedBg: "rgba(254, 249, 195, 0.5)",
+          border: "#e5e7eb",
+          textPrimary: "#374151",
+          textSecondary: "#6b7280",
+          textTertiary: "#9ca3af",
+          axisLine: "#d1d5db",
+          gridLine: "#e5e7eb",
+        };
+
     // Clear
     ctx.clearRect(0, 0, width, height);
 
@@ -85,26 +110,31 @@ export default function SwimLanes({ sessions, events }: SwimLanesProps) {
     activeSessions.forEach((session, idx) => {
       const y = PADDING + idx * (LANE_HEIGHT + LANE_GAP);
 
-      // Lane background
-      ctx.fillStyle = session.status === "queued" ? "#fef9c3" : "#f0f9ff";
-      ctx.globalAlpha = 0.3;
-      ctx.fillRect(0, y, width, LANE_HEIGHT);
-      ctx.globalAlpha = 1;
+      // Lane background with rounded corners
+      ctx.fillStyle = session.status === "queued" ? colors.queuedBg : colors.laneBg;
+      ctx.beginPath();
+      const radius = 8;
+      ctx.roundRect(0, y, width, LANE_HEIGHT, radius);
+      ctx.fill();
 
       // Lane border
-      ctx.strokeStyle = "#e5e7eb";
+      ctx.strokeStyle = colors.border;
       ctx.lineWidth = 1;
-      ctx.strokeRect(0, y, width, LANE_HEIGHT);
+      ctx.beginPath();
+      ctx.roundRect(0, y, width, LANE_HEIGHT, radius);
+      ctx.stroke();
 
-      // Session color indicator
+      // Session color indicator (rounded left side)
       ctx.fillStyle = session.color;
-      ctx.fillRect(0, y, 4, LANE_HEIGHT);
+      ctx.beginPath();
+      ctx.roundRect(0, y, 4, LANE_HEIGHT, [radius, 0, 0, radius]);
+      ctx.fill();
 
       // Header text
       const issue = mockIssues.find((i) => i.id === session.issueId);
       const project = mockProjects.find((p) => p.id === session.projectId);
 
-      ctx.fillStyle = "#374151";
+      ctx.fillStyle = colors.textPrimary;
       ctx.font = "bold 12px 'Geist Variable', sans-serif";
       ctx.fillText(
         project?.name ?? "unknown",
@@ -112,22 +142,22 @@ export default function SwimLanes({ sessions, events }: SwimLanesProps) {
         y + 20
       );
 
-      ctx.fillStyle = "#6b7280";
-      ctx.font = "11px 'Geist Variable', monospace";
+      ctx.fillStyle = colors.textTertiary;
+      ctx.font = "11px 'Geist Mono', ui-monospace, monospace";
       ctx.fillText(
         session.sessionId.slice(0, 20),
         12,
         y + 34
       );
 
-      ctx.fillStyle = "#374151";
+      ctx.fillStyle = colors.textSecondary;
       ctx.font = "11px 'Geist Variable', sans-serif";
       const issueLabel = issue ? `#${issue.issueNumber} ${issue.title.slice(0, 24)}...` : "No issue";
       ctx.fillText(issueLabel, 12, y + 50);
 
       // Counters
-      ctx.fillStyle = "#9ca3af";
-      ctx.font = "10px 'Geist Variable', sans-serif";
+      ctx.fillStyle = colors.textTertiary;
+      ctx.font = "10px 'Geist Mono', ui-monospace, monospace";
       ctx.fillText(
         `${session.eventCount} events | ${session.toolCount} tools | ${session.model.split("-").slice(0, 2).join("-")}`,
         12,
@@ -135,13 +165,15 @@ export default function SwimLanes({ sessions, events }: SwimLanesProps) {
       );
 
       // Timeline axis line
-      ctx.strokeStyle = "#d1d5db";
+      ctx.strokeStyle = colors.axisLine;
       ctx.lineWidth = 1;
+      ctx.setLineDash([4, 4]);
       ctx.beginPath();
       const laneMidY = y + LANE_HEIGHT / 2;
       ctx.moveTo(HEADER_WIDTH + PADDING, laneMidY);
       ctx.lineTo(width - PADDING, laneMidY);
       ctx.stroke();
+      ctx.setLineDash([]);
 
       // Plot events for this session
       const sessionEvents = events.filter(
@@ -152,15 +184,18 @@ export default function SwimLanes({ sessions, events }: SwimLanesProps) {
         const ex = timeToX(event.timestamp);
         const ey = laneMidY;
 
-        // Draw event dot
+        // Draw event dot with shadow
+        ctx.shadowColor = getToolColor(event.toolName);
+        ctx.shadowBlur = 4;
         ctx.beginPath();
         ctx.arc(ex, ey, EVENT_RADIUS, 0, Math.PI * 2);
         ctx.fillStyle = getToolColor(event.toolName);
         ctx.fill();
+        ctx.shadowBlur = 0;
 
-        // Outline for hook vs orchestration
+        // Outline for orchestration events (double ring)
         if (event.source === "orchestration") {
-          ctx.strokeStyle = "#1f2937";
+          ctx.strokeStyle = isDark ? "#e2e8f0" : "#1f2937";
           ctx.lineWidth = 2;
           ctx.stroke();
         }
@@ -169,8 +204,8 @@ export default function SwimLanes({ sessions, events }: SwimLanesProps) {
 
     // Time axis labels
     const tickCount = 6;
-    ctx.fillStyle = "#9ca3af";
-    ctx.font = "10px 'Geist Variable', monospace";
+    ctx.fillStyle = colors.textTertiary;
+    ctx.font = "10px 'Geist Mono', ui-monospace, monospace";
     for (let i = 0; i <= tickCount; i++) {
       const t = minTime + (timeRange * i) / tickCount;
       const x = HEADER_WIDTH + PADDING + (timelineWidth * i) / tickCount;
@@ -178,24 +213,24 @@ export default function SwimLanes({ sessions, events }: SwimLanesProps) {
       const label = `${date.getUTCHours().toString().padStart(2, "0")}:${date.getUTCMinutes().toString().padStart(2, "0")}`;
       ctx.fillText(label, x - 14, PADDING + activeSessions.length * (LANE_HEIGHT + LANE_GAP) + 4);
     }
-  }, [activeSessions, events, minTime, maxTime]);
+  }, [activeSessions, events, minTime, maxTime, isDark]);
 
   return (
-    <div className="rounded-lg border border-border bg-card overflow-hidden">
-      <div className="flex items-center justify-between border-b border-border px-4 py-2">
+    <div className="rounded-xl border border-border bg-card overflow-hidden shadow-sm">
+      <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
         <h3 className="text-sm font-semibold">Swim Lanes</h3>
         <div className="flex items-center gap-3 text-xs text-muted-foreground">
           {Object.entries(TOOL_COLORS).map(([tool, color]) => (
-            <span key={tool} className="flex items-center gap-1">
+            <span key={tool} className="flex items-center gap-1.5">
               <span
-                className="inline-block size-2.5 rounded-full"
+                className="inline-block size-2.5 rounded-full shadow-sm"
                 style={{ backgroundColor: color }}
               />
               {tool}
             </span>
           ))}
-          <span className="flex items-center gap-1">
-            <span className="inline-block size-2.5 rounded-full bg-gray-500" />
+          <span className="flex items-center gap-1.5">
+            <span className="inline-block size-2.5 rounded-full bg-gray-500 shadow-sm" />
             Other
           </span>
         </div>

--- a/src/components/agents/TraceTree.tsx
+++ b/src/components/agents/TraceTree.tsx
@@ -11,10 +11,10 @@ interface TraceTreeProps {
 }
 
 const LEVEL_COLORS: Record<string, string> = {
-  session: "bg-purple-100 text-purple-800",
-  step: "bg-blue-100 text-blue-800",
-  cli_call: "bg-amber-100 text-amber-800",
-  tool_use: "bg-green-100 text-green-800",
+  session: "bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300",
+  step: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300",
+  cli_call: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300",
+  tool_use: "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300",
 };
 
 const WATERFALL_COLORS: Record<string, string> = {
@@ -39,16 +39,18 @@ function TraceNode({
   depth,
   globalStart,
   globalEnd,
+  isLast,
 }: {
   trace: AgentTrace;
   depth: number;
   globalStart: number;
   globalEnd: number;
+  isLast: boolean;
 }) {
   const [expanded, setExpanded] = useState(depth < 2);
 
   const hasChildren = trace.children && trace.children.length > 0;
-  const indentPx = depth * 20;
+  const indentPx = depth * 24;
 
   // Waterfall bar calculation
   const traceStart = new Date(trace.startedAt).getTime();
@@ -62,28 +64,54 @@ function TraceNode({
     0.5
   );
 
+  const waterfallColor = WATERFALL_COLORS[trace.level] ?? "#6b7280";
+
   return (
     <div>
       <div
-        className="flex items-center gap-1 py-1 hover:bg-accent/30 transition-colors cursor-pointer group"
+        className="flex items-center gap-1.5 py-1.5 hover:bg-accent/30 transition-colors cursor-pointer group relative"
         style={{ paddingLeft: indentPx + 8 }}
         onClick={() => hasChildren && setExpanded(!expanded)}
       >
+        {/* Tree connector lines */}
+        {depth > 0 && (
+          <>
+            {/* Vertical connector from parent */}
+            <span
+              className="absolute border-l border-border/60 dark:border-border/40"
+              style={{
+                left: indentPx - 12 + 8,
+                top: 0,
+                height: isLast ? "50%" : "100%",
+              }}
+            />
+            {/* Horizontal connector to node */}
+            <span
+              className="absolute border-t border-border/60 dark:border-border/40"
+              style={{
+                left: indentPx - 12 + 8,
+                top: "50%",
+                width: 12,
+              }}
+            />
+          </>
+        )}
+
         {/* Expand/collapse or spacer */}
         {hasChildren ? (
           expanded ? (
-            <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+            <ChevronDown className="size-3.5 shrink-0 text-muted-foreground transition-transform" />
           ) : (
-            <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+            <ChevronRight className="size-3.5 shrink-0 text-muted-foreground transition-transform" />
           )
         ) : (
-          <span className="inline-block w-3.5" />
+          <span className="inline-block w-3.5 shrink-0" />
         )}
 
         {/* Level badge */}
         <Badge
           variant="secondary"
-          className={`text-[10px] shrink-0 ${LEVEL_COLORS[trace.level] ?? ""}`}
+          className={`text-[10px] shrink-0 border-none ${LEVEL_COLORS[trace.level] ?? ""}`}
         >
           {trace.level}
         </Badge>
@@ -94,34 +122,37 @@ function TraceNode({
         </span>
 
         {/* Duration */}
-        <span className="flex items-center gap-0.5 text-[10px] text-muted-foreground ml-auto mr-2 shrink-0">
+        <span className="flex items-center gap-0.5 font-technical text-[10px] text-muted-foreground ml-auto mr-2 shrink-0">
           <Clock className="size-2.5" />
           {formatDuration(trace.startedAt, trace.endedAt)}
         </span>
 
-        {/* Waterfall bar */}
-        <div className="relative w-[200px] h-3 shrink-0 bg-muted/40 rounded-sm overflow-hidden">
+        {/* Waterfall bar with gradient */}
+        <div className="relative w-[200px] h-4 shrink-0 bg-muted/30 dark:bg-muted/20 rounded-md overflow-hidden">
           <div
-            className="absolute top-0 h-full rounded-sm opacity-80"
-            style={{
-              left: `${barLeft}%`,
-              width: `${barWidth}%`,
-              backgroundColor: WATERFALL_COLORS[trace.level] ?? "#6b7280",
-            }}
+            className="absolute top-0.5 bottom-0.5 rounded-sm waterfall-bar"
+            style={
+              {
+                left: `${barLeft}%`,
+                width: `${barWidth}%`,
+                "--waterfall-color": waterfallColor,
+              } as React.CSSProperties
+            }
           />
         </div>
       </div>
 
       {/* Children */}
       {expanded && hasChildren && (
-        <div>
-          {trace.children!.map((child) => (
+        <div className="relative">
+          {trace.children!.map((child, idx) => (
             <TraceNode
               key={child.id}
               trace={child}
               depth={depth + 1}
               globalStart={globalStart}
               globalEnd={globalEnd}
+              isLast={idx === trace.children!.length - 1}
             />
           ))}
         </div>
@@ -157,13 +188,13 @@ export default function TraceTree({ traces, selectedSessionId }: TraceTreeProps)
   })();
 
   return (
-    <div className="rounded-lg border border-border bg-card">
-      <div className="flex items-center justify-between border-b border-border px-4 py-2">
+    <div className="rounded-xl border border-border bg-card shadow-sm">
+      <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
         <h3 className="text-sm font-semibold">Trace View</h3>
         <div className="flex items-center gap-3 text-xs text-muted-foreground">
           {Object.entries(LEVEL_COLORS).map(([level, cls]) => (
             <span key={level} className="flex items-center gap-1">
-              <Badge variant="secondary" className={`text-[9px] px-1 py-0 ${cls}`}>
+              <Badge variant="secondary" className={`text-[9px] px-1.5 py-0 border-none ${cls}`}>
                 {level}
               </Badge>
             </span>
@@ -174,13 +205,14 @@ export default function TraceTree({ traces, selectedSessionId }: TraceTreeProps)
       <ScrollArea className="h-[400px]">
         <div className="py-1">
           {displayTraces.length > 0 ? (
-            displayTraces.map((trace) => (
+            displayTraces.map((trace, idx) => (
               <TraceNode
                 key={trace.id}
                 trace={trace}
                 depth={0}
                 globalStart={globalStart}
                 globalEnd={globalEnd}
+                isLast={idx === displayTraces.length - 1}
               />
             ))
           ) : (

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -35,7 +35,7 @@ function renderContent(text: string) {
       parts.push(
         <code
           key={keyIdx++}
-          className="rounded bg-muted px-1 py-0.5 text-xs font-mono"
+          className="rounded bg-muted px-1.5 py-0.5 font-technical text-xs"
         >
           {match[3]}
         </code>
@@ -72,7 +72,7 @@ export default function ChatMessage({ message }: ChatMessageProps) {
   return (
     <div className={cn("flex gap-2", isOp ? "justify-start" : "justify-end")}>
       {isOp && (
-        <div className="mt-1 flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/10">
+        <div className="mt-1 flex size-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-primary/20 to-primary/5">
           <Sparkles className="size-3.5 text-primary" />
         </div>
       )}
@@ -103,7 +103,7 @@ export default function ChatMessage({ message }: ChatMessageProps) {
         {/* Message bubble */}
         <div
           className={cn(
-            "rounded-2xl px-3.5 py-2 text-sm leading-relaxed",
+            "rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed shadow-sm",
             isOp
               ? "rounded-tl-sm bg-muted text-foreground"
               : "rounded-tr-sm bg-primary text-primary-foreground"

--- a/src/components/chat/ChatOptions.tsx
+++ b/src/components/chat/ChatOptions.tsx
@@ -41,7 +41,7 @@ export default function ChatOptions({
   };
 
   return (
-    <div className="flex flex-col gap-2 border-t border-border bg-card px-4 py-3">
+    <div className="flex flex-col gap-2 border-t border-border bg-card/50 px-4 py-3">
       {!showCustomInput ? (
         <div className="flex flex-col gap-1.5">
           {options.map((option) => (
@@ -49,12 +49,15 @@ export default function ChatOptions({
               key={option.value}
               onClick={() => handleOptionClick(option)}
               className={cn(
-                "rounded-lg border px-3 py-2 text-left text-sm transition-colors hover:bg-accent",
+                "rounded-lg border px-3 py-2 text-left text-sm transition-all duration-150",
                 option.recommended
-                  ? "border-primary/40 bg-primary/5 font-medium text-foreground hover:bg-primary/10"
-                  : "border-border text-foreground/80"
+                  ? "border-primary/40 bg-primary/5 font-medium text-foreground hover:bg-primary/10 hover:border-primary/60 hover:shadow-sm"
+                  : "border-border text-foreground/80 hover:bg-accent hover:border-border hover:shadow-sm"
               )}
             >
+              {option.recommended && (
+                <span className="mr-1.5 text-xs text-primary">*</span>
+              )}
               {option.label}
             </button>
           ))}
@@ -66,7 +69,7 @@ export default function ChatOptions({
             onChange={(e) => setCustomText(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Type your response..."
-            className="flex-1 resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+            className="flex-1 resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring transition-shadow"
             rows={2}
             autoFocus
           />
@@ -74,7 +77,7 @@ export default function ChatOptions({
             size="icon"
             onClick={handleCustomSend}
             disabled={!customText.trim()}
-            className="shrink-0"
+            className="shrink-0 transition-transform hover:scale-105"
           >
             <Send className="size-4" />
           </Button>

--- a/src/components/chat/ChatPopover.tsx
+++ b/src/components/chat/ChatPopover.tsx
@@ -63,9 +63,9 @@ export default function ChatPopover() {
 
   return (
     <>
-      {/* Backdrop — subtle, allows click to close */}
+      {/* Backdrop -- subtle, allows click to close */}
       <div
-        className="fixed inset-0 z-40"
+        className="fixed inset-0 z-40 bg-black/5 dark:bg-black/20 transition-opacity"
         onClick={() => setChatOpen(false)}
       />
 
@@ -80,12 +80,12 @@ export default function ChatPopover() {
       >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-4 py-3">
-          <div className="flex items-center gap-2">
-            <div className="flex size-7 items-center justify-center rounded-full bg-primary/10">
-              <Sparkles className="size-3.5 text-primary" />
+          <div className="flex items-center gap-2.5">
+            <div className="flex size-8 items-center justify-center rounded-full bg-gradient-to-br from-primary/20 to-primary/5">
+              <Sparkles className="size-4 text-primary" />
             </div>
             <div className="flex flex-col">
-              <span className="text-sm font-semibold">Chat with OP (오피)</span>
+              <span className="text-sm font-semibold">Chat with OP</span>
               {project && (
                 <span className="text-xs text-muted-foreground">
                   {project.name}
@@ -96,7 +96,7 @@ export default function ChatPopover() {
           <Button
             variant="ghost"
             size="icon"
-            className="size-7"
+            className="size-7 transition-colors"
             onClick={() => setChatOpen(false)}
           >
             <X className="size-4" />
@@ -114,7 +114,7 @@ export default function ChatPopover() {
               {/* Typing indicator */}
               {isTyping && (
                 <div className="flex items-center gap-2">
-                  <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/10">
+                  <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-primary/20 to-primary/5">
                     <Sparkles className="size-3.5 text-primary" />
                   </div>
                   <div className="rounded-2xl rounded-tl-sm bg-muted px-3.5 py-2">
@@ -146,14 +146,14 @@ export default function ChatPopover() {
               onChange={(e) => setFreeText(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="Type a message..."
-              className="flex-1 resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              className="flex-1 resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring transition-shadow"
               rows={1}
             />
             <Button
               size="icon"
               onClick={handleFreeTextSend}
               disabled={!freeText.trim()}
-              className="shrink-0"
+              className="shrink-0 transition-transform hover:scale-105"
             >
               <Send className="size-4" />
             </Button>

--- a/src/components/dag/DagNode.tsx
+++ b/src/components/dag/DagNode.tsx
@@ -60,20 +60,20 @@ function DagNodeComponent({ data }: NodeProps<DagNodeType>) {
 
       <div
         className={cn(
-          "w-[240px] rounded-lg border bg-card text-card-foreground shadow-sm transition-shadow hover:shadow-md cursor-pointer overflow-hidden",
-          isExternal && "opacity-60 border-dashed border-muted-foreground/40"
+          "w-[240px] rounded-xl border bg-card text-card-foreground shadow-md transition-all duration-150 hover:shadow-lg cursor-pointer overflow-hidden",
+          isExternal && "opacity-50 border-dashed border-muted-foreground/40"
         )}
       >
         {/* Session color bar */}
         <div
-          className="h-1 w-full"
+          className="h-1.5 w-full"
           style={{ backgroundColor: sessionColor }}
         />
 
         <div className="flex flex-col gap-1.5 p-3">
           {/* Header row: issue number + type badge */}
           <div className="flex items-center justify-between">
-            <span className="text-xs font-medium text-muted-foreground">
+            <span className="font-technical text-xs font-medium text-muted-foreground">
               #{issue.issueNumber}
               {isExternal && (
                 <span className="ml-1 text-[10px] text-muted-foreground/70">

--- a/src/components/hi-queue/HiQueue.tsx
+++ b/src/components/hi-queue/HiQueue.tsx
@@ -19,12 +19,12 @@ export default function HiQueue() {
     <section className="flex flex-col gap-3">
       <div className="flex items-center gap-2">
         <MessageCircleWarning className="size-4 text-amber-500" />
-        <h2 className="text-sm font-semibold tracking-tight">
+        <h2 className="text-lg font-semibold tracking-tight">
           Human Intervention Queue
         </h2>
         <Badge
-          variant="secondary"
-          className="size-5 justify-center rounded-full p-0 text-xs font-semibold"
+          variant="destructive"
+          className="size-5 justify-center rounded-full p-0 text-[10px] font-bold"
         >
           {pendingItems.length}
         </Badge>

--- a/src/components/hi-queue/HiQueueItem.tsx
+++ b/src/components/hi-queue/HiQueueItem.tsx
@@ -32,13 +32,13 @@ export default function HiQueueItem({ item }: HiQueueItemProps) {
   return (
     <button
       onClick={handleClick}
-      className="group flex w-full items-start gap-3 rounded-lg border border-border bg-card p-3 text-left transition-colors hover:bg-accent/50"
+      className="hover-lift group flex w-full items-start gap-3 rounded-lg border border-amber-200 bg-card p-3 text-left transition-all duration-150 hover:border-amber-300 hover:bg-amber-50/50 dark:border-amber-800/50 dark:hover:border-amber-700/60 dark:hover:bg-amber-950/30"
     >
       {/* Pulse indicator for pending items */}
       <div className="mt-1.5 flex shrink-0 items-center">
-        <span className="relative flex size-2">
+        <span className="relative flex size-2.5">
           <span className="absolute inline-flex size-full animate-ping rounded-full bg-amber-400 opacity-75" />
-          <span className="relative inline-flex size-2 rounded-full bg-amber-500" />
+          <span className="relative inline-flex size-2.5 rounded-full bg-amber-500" />
         </span>
       </div>
 
@@ -47,11 +47,11 @@ export default function HiQueueItem({ item }: HiQueueItemProps) {
           <Badge variant="secondary" className="shrink-0 text-xs font-normal">
             {project?.name ?? "Unknown"}
           </Badge>
-          <span className="text-xs text-muted-foreground">
+          <span className="font-technical text-[11px] text-muted-foreground">
             {timeAgo(item.createdAt)}
           </span>
         </div>
-        <p className="text-sm leading-snug text-foreground line-clamp-2">
+        <p className="text-sm font-medium leading-snug text-foreground line-clamp-2">
           {item.promptText}
         </p>
         <div className="flex flex-wrap gap-1.5">
@@ -59,7 +59,7 @@ export default function HiQueueItem({ item }: HiQueueItemProps) {
             <Badge
               key={opt.action}
               variant={opt.recommended ? "default" : "outline"}
-              className="text-xs font-normal"
+              className="text-xs font-normal transition-colors"
             >
               {opt.label}
             </Badge>

--- a/src/components/kanban/IssueDetailModal.tsx
+++ b/src/components/kanban/IssueDetailModal.tsx
@@ -82,7 +82,7 @@ export default function IssueDetailModal({
                 href={issue.issueUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                className="inline-flex items-center gap-1 font-technical text-sm text-muted-foreground hover:text-foreground transition-colors"
               >
                 #{issue.issueNumber}
                 <ExternalLinkIcon className="size-3" />
@@ -106,9 +106,9 @@ export default function IssueDetailModal({
         )}
 
         {/* Details grid */}
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-2 gap-4">
           {/* Session */}
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-1.5 rounded-lg bg-muted/30 p-3">
             <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
               Session
             </span>
@@ -122,7 +122,7 @@ export default function IssueDetailModal({
           </div>
 
           {/* Verification status */}
-          <div className="flex flex-col gap-1">
+          <div className="flex flex-col gap-1.5 rounded-lg bg-muted/30 p-3">
             <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
               Verification
             </span>
@@ -147,7 +147,7 @@ export default function IssueDetailModal({
 
           {/* PR link */}
           {issue.prNumber && (
-            <div className="flex flex-col gap-1">
+            <div className="flex flex-col gap-1.5 rounded-lg bg-muted/30 p-3">
               <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
                 Pull Request
               </span>
@@ -166,7 +166,7 @@ export default function IssueDetailModal({
 
           {/* Requirement IDs */}
           {issue.requirementIds && issue.requirementIds.length > 0 && (
-            <div className="flex flex-col gap-1">
+            <div className="flex flex-col gap-1.5 rounded-lg bg-muted/30 p-3">
               <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
                 Requirements
               </span>
@@ -175,7 +175,7 @@ export default function IssueDetailModal({
                   <Badge
                     key={reqId}
                     variant="secondary"
-                    className="text-[10px] font-mono"
+                    className="font-technical text-[10px]"
                   >
                     {reqId}
                   </Badge>

--- a/src/components/kanban/KanbanBoard.tsx
+++ b/src/components/kanban/KanbanBoard.tsx
@@ -36,7 +36,7 @@ export default function KanbanBoard({ projectId }: KanbanBoardProps) {
   return (
     <section className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold tracking-tight">Board</h2>
+        <h2 className="text-lg font-semibold tracking-tight">Board</h2>
         <SessionFilter
           sessions={projectSessions}
           value={selectedSession}

--- a/src/components/kanban/KanbanCard.tsx
+++ b/src/components/kanban/KanbanCard.tsx
@@ -35,19 +35,14 @@ export default function KanbanCard({ issue, onClick }: KanbanCardProps) {
 
   return (
     <Card
-      className="cursor-pointer gap-0 overflow-hidden border-border py-0 transition-shadow hover:shadow-md"
+      className="hover-lift cursor-pointer gap-0 overflow-hidden border-border py-0 transition-all duration-150"
+      style={{ borderLeftColor: session?.color ?? "#888", borderLeftWidth: 3 }}
       onClick={() => onClick?.(issue)}
     >
-      {/* Session color bar */}
-      <div
-        className="h-1 w-full"
-        style={{ backgroundColor: session?.color ?? "#888" }}
-      />
-
       <div className="flex flex-col gap-2 p-3">
         {/* Header: issue number + type badge */}
         <div className="flex items-center justify-between">
-          <span className="text-xs font-medium text-muted-foreground">
+          <span className="font-technical text-xs font-medium text-muted-foreground">
             #{issue.issueNumber}
           </span>
           <Badge
@@ -76,7 +71,7 @@ export default function KanbanCard({ issue, onClick }: KanbanCardProps) {
             </Badge>
           )}
           {issue.prNumber && (
-            <span className="text-[10px] text-muted-foreground">
+            <span className="font-technical text-[10px] text-muted-foreground">
               PR #{issue.prNumber}
             </span>
           )}

--- a/src/components/kanban/KanbanColumn.tsx
+++ b/src/components/kanban/KanbanColumn.tsx
@@ -3,13 +3,23 @@ import type { Issue, KanbanColumnConfig } from "@/types";
 import KanbanCard from "./KanbanCard";
 
 const columnBgStyles: Record<string, string> = {
-  discussing: "bg-purple-500/5",
-  todo: "bg-slate-500/5",
-  in_progress: "bg-blue-500/5",
-  verifying: "bg-amber-500/5",
-  done: "bg-emerald-500/5",
-  failed: "bg-rose-500/5",
-  deferred: "bg-slate-500/5",
+  discussing: "bg-purple-500/5 dark:bg-purple-500/10",
+  todo: "bg-slate-500/5 dark:bg-slate-500/10",
+  in_progress: "bg-blue-500/5 dark:bg-blue-500/10",
+  verifying: "bg-amber-500/5 dark:bg-amber-500/10",
+  done: "bg-emerald-500/5 dark:bg-emerald-500/10",
+  failed: "bg-rose-500/5 dark:bg-rose-500/10",
+  deferred: "bg-slate-500/5 dark:bg-slate-500/10",
+};
+
+const columnCountColors: Record<string, string> = {
+  discussing: "bg-purple-100 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300",
+  todo: "bg-slate-100 text-slate-700 dark:bg-slate-800/50 dark:text-slate-300",
+  in_progress: "bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300",
+  verifying: "bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300",
+  done: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300",
+  failed: "bg-rose-100 text-rose-700 dark:bg-rose-900/50 dark:text-rose-300",
+  deferred: "bg-slate-100 text-slate-700 dark:bg-slate-800/50 dark:text-slate-300",
 };
 
 interface KanbanColumnProps {
@@ -21,18 +31,19 @@ interface KanbanColumnProps {
 export default function KanbanColumn({ config, issues, onCardClick }: KanbanColumnProps) {
   return (
     <div
-      className={`flex h-full w-64 shrink-0 flex-col rounded-lg ${
+      className={`flex h-full w-64 shrink-0 flex-col rounded-xl border border-border/50 ${
         columnBgStyles[config.id] ?? "bg-muted/30"
       }`}
     >
       {/* Column header */}
-      <div className="flex items-center gap-2 px-3 py-2.5">
+      <div className="flex items-center gap-2 px-3 py-3">
         <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           {config.title}
         </h3>
         <Badge
-          variant="secondary"
-          className="size-5 justify-center rounded-full p-0 text-[10px] font-semibold"
+          className={`size-5 justify-center rounded-full border-none p-0 text-[10px] font-bold ${
+            columnCountColors[config.id] ?? "bg-muted text-muted-foreground"
+          }`}
         >
           {issues.length}
         </Badge>

--- a/src/components/settings/ProjectList.tsx
+++ b/src/components/settings/ProjectList.tsx
@@ -7,10 +7,10 @@ interface ProjectListProps {
   projects: Project[];
 }
 
-const providerVariant: Record<string, "default" | "secondary" | "outline"> = {
-  github: "default",
-  gitlab: "secondary",
-  jira: "outline",
+const providerStyles: Record<string, string> = {
+  github: "bg-gray-900 text-white dark:bg-gray-700",
+  gitlab: "bg-orange-600 text-white",
+  jira: "bg-blue-600 text-white",
 };
 
 export default function ProjectList({ projects }: ProjectListProps) {
@@ -25,20 +25,24 @@ export default function ProjectList({ projects }: ProjectListProps) {
   }
 
   return (
-    <ul className="space-y-3">
+    <ul className="space-y-2">
       {projects.map((project) => (
         <li
           key={project.id}
-          className="flex items-center justify-between rounded-lg border px-4 py-3"
+          className="flex items-center justify-between rounded-lg border border-border bg-background px-4 py-3 transition-colors hover:bg-accent/30"
         >
           <div className="flex flex-col gap-1">
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium">{project.name}</span>
-              <Badge variant={providerVariant[project.provider] ?? "outline"}>
+              <Badge
+                className={`border-none text-[10px] font-medium uppercase tracking-wider ${
+                  providerStyles[project.provider] ?? "bg-muted text-muted-foreground"
+                }`}
+              >
                 {project.provider}
               </Badge>
             </div>
-            <span className="text-xs text-muted-foreground">
+            <span className="font-technical text-xs text-muted-foreground">
               {project.remoteUrl}
             </span>
           </div>
@@ -47,8 +51,9 @@ export default function ProjectList({ projects }: ProjectListProps) {
             size="icon-sm"
             onClick={() => handleRemove(project)}
             aria-label={`Remove ${project.name}`}
+            className="text-muted-foreground hover:text-destructive transition-colors"
           >
-            <Trash2 className="size-4 text-muted-foreground" />
+            <Trash2 className="size-4" />
           </Button>
         </li>
       ))}

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,7 +1,9 @@
-import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from "react";
 import type { Project } from "@/types";
 import { mockProjects } from "@/data/mock-projects";
 import { mockConversations } from "@/data/mock-conversations";
+
+type Theme = "light" | "dark";
 
 interface AppContextValue {
   currentProject: Project;
@@ -13,14 +15,42 @@ interface AppContextValue {
   setActiveChatConversationId: (id: string | null) => void;
   openChatForHiItem: (hiItemId: string) => void;
   openChatDefault: () => void;
+  // Theme
+  theme: Theme;
+  toggleTheme: () => void;
+  isDark: boolean;
 }
 
 const AppContext = createContext<AppContextValue | null>(null);
+
+function getInitialTheme(): Theme {
+  if (typeof window !== "undefined") {
+    const stored = localStorage.getItem("autopilot-theme");
+    if (stored === "dark" || stored === "light") return stored;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+  return "light";
+}
 
 export function AppProvider({ children }: { children: ReactNode }) {
   const [currentProject, setCurrentProject] = useState<Project>(mockProjects[0]);
   const [chatOpen, setChatOpen] = useState(false);
   const [activeChatConversationId, setActiveChatConversationId] = useState<string | null>(null);
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    localStorage.setItem("autopilot-theme", theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((t) => (t === "dark" ? "light" : "dark"));
+  }, []);
 
   const openChatForHiItem = useCallback((hiItemId: string) => {
     // Find conversation linked to this HI item
@@ -52,6 +82,9 @@ export function AppProvider({ children }: { children: ReactNode }) {
         setActiveChatConversationId,
         openChatForHiItem,
         openChatDefault,
+        theme,
+        toggleTheme,
+        isDark: theme === "dark",
       }}
     >
       {children}

--- a/src/index.css
+++ b/src/index.css
@@ -127,3 +127,92 @@
     @apply font-sans;
     }
 }
+
+/* ── Dark mode toggle transition ── */
+html {
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+/* ── Pulse animation for running status dots ── */
+@keyframes status-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.6; transform: scale(1.3); }
+}
+.animate-status-pulse {
+  animation: status-pulse 2s ease-in-out infinite;
+}
+
+/* ── Page transition fade ── */
+@keyframes page-enter {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.animate-page-enter {
+  animation: page-enter 0.25s ease-out;
+}
+
+/* ── Panel expand/collapse ── */
+@keyframes panel-expand {
+  from { opacity: 0; max-height: 0; }
+  to { opacity: 1; max-height: 600px; }
+}
+.animate-panel-expand {
+  animation: panel-expand 0.2s ease-out;
+  overflow: hidden;
+}
+
+/* ── Hover lift for cards ── */
+.hover-lift {
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.hover-lift:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+.dark .hover-lift:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+/* ── Sidebar active indicator bar ── */
+.nav-active-bar {
+  position: relative;
+}
+.nav-active-bar::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 60%;
+  border-radius: 0 3px 3px 0;
+  background: var(--color-primary);
+  transition: opacity 0.15s ease;
+}
+
+/* ── Monospace for technical values ── */
+.font-technical {
+  font-family: 'Geist Mono', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Waterfall bar gradient ── */
+.waterfall-bar {
+  background: linear-gradient(90deg, var(--waterfall-color) 0%, color-mix(in oklch, var(--waterfall-color), transparent 40%) 100%);
+}
+
+/* ── React Flow dark mode overrides ── */
+.dark .react-flow__background {
+  background-color: var(--color-background);
+}
+.dark .react-flow__minimap {
+  background-color: var(--color-card) !important;
+}
+.dark .react-flow__controls button {
+  background-color: var(--color-card) !important;
+  color: var(--color-foreground) !important;
+  border-color: var(--color-border) !important;
+}
+.dark .react-flow__controls button:hover {
+  background-color: var(--color-accent) !important;
+}

--- a/src/pages/AgentsPage.tsx
+++ b/src/pages/AgentsPage.tsx
@@ -23,14 +23,14 @@ export default function AgentsPage() {
   );
 
   return (
-    <div className="flex flex-col gap-4 p-6">
+    <div className="flex flex-col gap-6 p-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-lg font-semibold">Agents</h1>
-          <p className="text-sm text-muted-foreground">
+          <h1 className="text-lg font-semibold tracking-tight">Agents</h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
             {currentProject
               ? `Scoped to ${currentProject.name}`
-              : "Global view — all projects"}
+              : "Global view -- all projects"}
           </p>
         </div>
 
@@ -38,7 +38,7 @@ export default function AgentsPage() {
         <div className="flex items-center gap-2">
           <label className="text-xs text-muted-foreground">Trace session:</label>
           <select
-            className="rounded border border-border bg-background px-2 py-1 text-xs"
+            className="rounded-md border border-border bg-background px-2.5 py-1.5 font-technical text-xs transition-colors focus:outline-none focus:ring-2 focus:ring-ring"
             value={selectedSessionId ?? ""}
             onChange={(e) =>
               setSelectedSessionId(e.target.value || null)
@@ -54,7 +54,7 @@ export default function AgentsPage() {
         </div>
       </div>
 
-      {/* Swim Lanes — canvas-based timeline */}
+      {/* Swim Lanes -- canvas-based timeline */}
       <SwimLanes sessions={scopedSessions} events={scopedEvents} />
 
       {/* Middle row: Pulse Chart + Event Feed side by side */}
@@ -63,7 +63,7 @@ export default function AgentsPage() {
         <EventFeed events={scopedEvents} projectId={currentProject?.id} />
       </div>
 
-      {/* Trace Tree — expandable hierarchical view */}
+      {/* Trace Tree -- expandable hierarchical view */}
       <TraceTree traces={mockAgentTraces} selectedSessionId={selectedSessionId} />
     </div>
   );

--- a/src/pages/DagPage.tsx
+++ b/src/pages/DagPage.tsx
@@ -67,7 +67,7 @@ function layoutGraph(
 }
 
 export default function DagPage() {
-  const { currentProject } = useApp();
+  const { currentProject, isDark } = useApp();
   const [selectedIssue, setSelectedIssue] = useState<Issue | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -111,16 +111,17 @@ export default function DagPage() {
       };
     });
 
-    // Build React Flow edges
+    // Build React Flow edges with theme-aware colors
+    const edgeColor = isDark ? "rgba(148, 163, 184, 0.5)" : "var(--color-muted-foreground)";
     const rfEdges: Edge[] = relevantEdges.map((e, idx) => ({
       id: `edge-${idx}`,
       source: e.from,
       target: e.to,
       animated: true,
-      style: { stroke: "var(--color-muted-foreground)", strokeWidth: 1.5 },
+      style: { stroke: edgeColor, strokeWidth: 1.5 },
       markerEnd: {
         type: MarkerType.ArrowClosed,
-        color: "var(--color-muted-foreground)",
+        color: edgeColor,
         width: 16,
         height: 16,
       },
@@ -130,7 +131,7 @@ export default function DagPage() {
     const laidOutNodes = layoutGraph(rfNodes, rfEdges);
 
     return { initialNodes: laidOutNodes, initialEdges: rfEdges };
-  }, [currentProject.id]);
+  }, [currentProject.id, isDark]);
 
   const [nodes, , onNodesChange] = useNodesState(initialNodes);
   const [edges, , onEdgesChange] = useEdgesState(initialEdges);
@@ -150,10 +151,10 @@ export default function DagPage() {
     <div className="flex h-full flex-col">
       {/* Header */}
       <div className="shrink-0 border-b px-6 py-4">
-        <h1 className="text-2xl font-semibold tracking-tight">
+        <h1 className="text-lg font-semibold tracking-tight">
           Dependency Graph
         </h1>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <p className="mt-0.5 text-sm text-muted-foreground">
           Issue dependencies for{" "}
           <span className="font-medium text-foreground">
             {currentProject.name}
@@ -177,14 +178,14 @@ export default function DagPage() {
           maxZoom={2}
           proOptions={{ hideAttribution: true }}
         >
-          <Controls className="!bg-card !border-border !shadow-md [&>button]:!bg-card [&>button]:!border-border [&>button]:!text-foreground hover:[&>button]:!bg-accent" />
+          <Controls className="!bg-card !border-border !shadow-md !rounded-lg [&>button]:!bg-card [&>button]:!border-border [&>button]:!text-foreground hover:[&>button]:!bg-accent" />
           <MiniMap
-            className="!bg-card !border-border !shadow-md"
+            className="!bg-card !border-border !shadow-md !rounded-lg"
             nodeColor={(node) => {
               const data = node.data as DagNodeData;
               return data.sessionColor;
             }}
-            maskColor="rgba(0, 0, 0, 0.1)"
+            maskColor={isDark ? "rgba(0, 0, 0, 0.3)" : "rgba(0, 0, 0, 0.1)"}
             pannable
             zoomable
           />
@@ -192,7 +193,7 @@ export default function DagPage() {
             variant={BackgroundVariant.Dots}
             gap={20}
             size={1}
-            color="var(--color-border)"
+            color={isDark ? "rgba(255, 255, 255, 0.06)" : "var(--color-border)"}
           />
         </ReactFlow>
       </div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -13,17 +13,17 @@ import ConfigSettings from "@/components/settings/ConfigSettings";
 
 export default function SettingsPage() {
   return (
-    <div className="p-6 space-y-6">
+    <div className="p-6 space-y-6 max-w-4xl">
       <div>
-        <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
+        <h1 className="text-lg font-semibold tracking-tight">Settings</h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
           Manage projects, authentication, and configuration.
         </p>
       </div>
 
-      <Card>
+      <Card className="shadow-sm">
         <CardHeader>
-          <CardTitle>Projects</CardTitle>
+          <CardTitle className="text-base">Projects</CardTitle>
           <CardDescription>
             Registered projects and their remote repositories.
           </CardDescription>
@@ -37,9 +37,9 @@ export default function SettingsPage() {
         </CardContent>
       </Card>
 
-      <Card>
+      <Card className="shadow-sm">
         <CardHeader>
-          <CardTitle>Authentication</CardTitle>
+          <CardTitle className="text-base">Authentication</CardTitle>
           <CardDescription>
             API tokens for Claude Code and source-control providers.
           </CardDescription>
@@ -49,9 +49,9 @@ export default function SettingsPage() {
         </CardContent>
       </Card>
 
-      <Card>
+      <Card className="shadow-sm">
         <CardHeader>
-          <CardTitle>Configuration</CardTitle>
+          <CardTitle className="text-base">Configuration</CardTitle>
           <CardDescription>
             Autopilot runtime parameters.
           </CardDescription>


### PR DESCRIPTION
## Summary

- **Dark mode**: Full support with theme toggle in sidebar, localStorage persistence, canvas components (SwimLanes, PulseChart) using theme-aware color palettes, React Flow DAG dark/light adaptation
- **Sidebar**: Active state left-accent bar, project switcher with avatar initials, hover translate animation, moon/sun toggle
- **Home page**: HI queue cards with amber urgency border and hover-lift; Kanban cards with left session-color border, semantic column count badges, rounded columns; Agent activity panel with pulse animation on running dots and expand/collapse animation
- **Agents page**: Swim lanes with rounded backgrounds, dashed axis lines, event glow; Event feed with row hover, distinct source badges (orchestration/hook), tool name badges; Pulse chart with rounded bars and agent line glow; Trace tree with gradient waterfall bars, tree connector lines
- **DAG/Settings/Chat**: Rounded node shadows, provider brand badges, gradient OP avatar, backdrop dim, message bubble shadows, recommended option indicators
- **Typography & animations**: Consistent heading scale, `font-technical` monospace class, hover-lift, page-enter fade, panel-expand, status-pulse animations

## Test plan

- [ ] `bun run build` passes (verified)
- [ ] Toggle dark mode via sidebar button -- all views render correctly in both themes
- [ ] Navigate between pages -- page-enter fade animation visible
- [ ] Home: HI queue cards show amber border and lift on hover
- [ ] Home: Kanban cards show left session-color border accent
- [ ] Home: Agent activity panel expands/collapses with animation, running agents pulse
- [ ] Agents: Swim lanes render with theme-appropriate colors in canvas
- [ ] Agents: Event feed rows highlight on hover, source badges are orange/cyan
- [ ] Agents: Pulse chart renders rounded bars, agent line glows
- [ ] Agents: Trace tree shows connector lines and gradient waterfall bars
- [ ] DAG: Nodes have rounded corners and shadows, edges adapt to theme
- [ ] Settings: Cards have consistent styling, provider badges use brand colors
- [ ] Chat: OP avatar has gradient, options show recommended indicator

Closes #10